### PR TITLE
Use websocket instead of ws r=lightsofapollo

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -1,6 +1,7 @@
-var WebSocketServer = require('ws').Server,
+var WebSocketServer = require('websocket').server,
     emptyPort = require('empty-port'),
-    debug = require('debug')('marionette-js-logger:server');
+    debug = require('debug')('marionette-js-logger:server'),
+    http = require('http');
 
 var PORT_START = 60000;
 
@@ -18,8 +19,9 @@ Server.prototype = {
   _initEvents: function(server) {
     this.ws = server;
 
-    server.on('connection', function(socket) {
-      socket.on('message', function(message) {
+    server.on('request', function(request) {
+      request.accept('echo-protocol', request.origin);
+      request.on('message', function(message) {
         var json;
         try {
           json = JSON.parse(message);
@@ -44,10 +46,22 @@ Server.prototype = {
     var self = this;
     function startServer(err, port) {
       if (err) return callback && callback(err);
+
+      var httpServer = http.createServer(function(req, res) {
+        console.log('[marionette log] http request for ' + req.url);
+        res.writeHead(404);
+        res.end();
+      });
+      server.listen(port);
+
+      var webSocketServer = new WebSocketServer({
+        httpServer: httpServer,
+        autoAcceptConnections: true
+      });
+
       self.port = port;
-      var server = new WebSocketServer({ port: port });
-      self._initEvents(server);
-      callback && callback(null, server, port);
+      self._initEvents(webSocketServer);
+      callback && callback(null, httpServer, port);
     }
 
     if (!port) {

--- a/package.json
+++ b/package.json
@@ -11,9 +11,9 @@
     "firefox"
   ],
   "dependencies" : {
-    "ws": "~0.4.25",
     "empty-port": "~0.0.1",
-    "debug": "*"
+    "debug": "*",
+    "websocket": "~1.0.7"
   },
   "devDependencies": {
     "mocha": "~1.12",


### PR DESCRIPTION
The tests weren't working for me locally (even before I made changes), so I haven't really tried this out yet, but it seemed like the right changeset from the websocket docs.
